### PR TITLE
Allow both 0.21.x and 1.x compatability

### DIFF
--- a/ArchSketchObject.py
+++ b/ArchSketchObject.py
@@ -2356,18 +2356,23 @@ FreeCADGui.addCommand('CellComplex', _Command_CellComplex())
 										
 def attachToMasterSketch(subject, target=None, subelement=None,			
                          attachmentOffset=None, zOffset='0',			
-                         intersectingSubelement=None, mapMode='ObjectXY'):	
-										
-  if Draft.getType(subject) == "ArchSketch":					
-      subject.MapReversed = False						
-      subject.MapMode = mapMode							
-      subject.AttachmentSupport = subject.MasterSketch				
-										
-										
-def detachFromMasterSketch(fp):							
-  fp.MapMode = 'Deactivated'							
-  fp.AttachmentSupport = None							
-										
+                         intersectingSubelement=None, mapMode='ObjectXY'):
+
+    if Draft.getType(subject) == "ArchSketch":
+        subject.MapReversed = False
+        subject.MapMode = mapMode
+        if hasattr(subject, "AttachmentSupport"):
+            subject.AttachmentSupport = subject.MasterSketch
+        else:
+            subject.Support = subject.MasterSketch
+
+
+def detachFromMasterSketch(fp):
+    fp.MapMode = "Deactivated"
+    if hasattr(fp, "AttachmentSupport"):
+        fp.AttachmentSupport = None
+    else:
+        fp.Support = None
 										
 def updatePropertiesLinkCommonODR(fp, linkFp=None, hostSketch=None):		
     updateAttachmentOffset(fp, linkFp, mode='ODR')				


### PR DESCRIPTION
@paullee0 until most of the regressions in 1.x are fixed there maybe a significant number of users sticking with 0.21.x so I thought it maybe worth allowing both for at least the near future.